### PR TITLE
Recent Pillow version in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ matplotlib==3.4.2
 mlrose==1.3.0
 networkx==2.6.1
 numpy==1.21.0
+Pillow==8.3.1
 pyvis==0.1.9
 scikit_learn==0.24.2
 scipy==1.7.0


### PR DESCRIPTION
...otherwise, the scripts fail with
`ImportError: cannot import name '_imaging' from 'PIL'`